### PR TITLE
chore: implement-logic-to-add-plants-to-user

### DIFF
--- a/src/app/api/v1/userPlant/route.ts
+++ b/src/app/api/v1/userPlant/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { UserPlants } from "@prisma/client"
+import { ResponseAPI } from "@/lib/@types/types"
+
+export const POST = async (request: NextRequest): Promise<NextResponse> => {
+    try {
+        const response = await request.json()
+        const { user, plant } = response
+        const existUser = await prisma.userPlants.findFirst({
+            where: { plantId: parseInt(plant), userId: parseInt(user) },
+        })
+
+        if (existUser) {
+            return NextResponse.json<ResponseAPI<{}>>({
+                data: {},
+                ok: false,
+                message: "This user is assigned to this plant",
+            })
+        }
+        const data = await prisma.userPlants.create({
+            data: {
+                plantId: parseInt(plant),
+                userId: parseInt(user),
+            },
+        })
+
+        return NextResponse.json<ResponseAPI<UserPlants>>({
+            data,
+            ok: true,
+            message: "The resource was created successfuly",
+        })
+    } catch (error) {
+        return NextResponse.json<ResponseAPI<{}>>({
+            data: {},
+            ok: false,
+            message: "Failed to create the plant to user",
+        })
+    }
+}

--- a/src/app/api/v1/users/[userId]/plants/route.ts
+++ b/src/app/api/v1/users/[userId]/plants/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { Plants } from "@prisma/client"
 import { Params, ResponseAPI } from "@/lib/@types/types"
+import { create } from "domain"
 
 /**
  * Handle the POST request to create a new plant related to a specific user
@@ -25,7 +26,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
     try {
         const userId = parseInt("0")
         const response = await request.json()
-        const { plantName, latitude, longitude } = response
+        const { plantName, latitude, longitude, user } = response
 
         const existcoordinates = await prisma.plants.findFirst({
             where: {
@@ -60,6 +61,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                 companyId: company?.companyId ?? 0,
                 latitude,
                 longitude,
+                UserPlants: {
+                    create: {
+                        userId: parseInt(user),
+                    },
+                },
             },
         })
 

--- a/src/app/api/v1/users/[userId]/userPlants/route.ts
+++ b/src/app/api/v1/users/[userId]/userPlants/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { UserPlants, Users } from "@prisma/client"
+import { Params, ResponseAPI } from "@/lib/@types/types"
+
+export const GET = async (request: NextRequest, { params }: Params<"userId">): Promise<NextResponse> => {
+    try {
+        const userId = parseInt(params.userId)
+        const company = await prisma.companies.findFirst({
+            where: {
+                Plants: {
+                    some: {
+                        UserPlants: {
+                            some: {
+                                userId: userId,
+                            },
+                        },
+                    },
+                },
+            },
+        })
+        const data = await prisma.userPlants.findMany({
+            where: {
+                plant: {
+                    companyId: company?.companyId,
+                },
+            },
+            include: {
+                user: true,
+                plant: true,
+            },
+        })
+        return NextResponse.json<ResponseAPI<UserPlants[]>>({
+            data,
+            ok: true,
+        })
+    } catch (error) {
+        return NextResponse.json<ResponseAPI<UserPlants[]>>(
+            {
+                data: [],
+                ok: false,
+                message: "Failed to retrieve the users",
+            },
+            { status: 404 }
+        )
+    }
+}

--- a/src/app/api/v1/users/[userId]/users/route.ts
+++ b/src/app/api/v1/users/[userId]/users/route.ts
@@ -25,7 +25,7 @@ import { Params, ResponseAPI } from "@/lib/@types/types"
 export const POST = async (request: NextRequest): Promise<NextResponse> => {
     try {
         const response = await request.json()
-        const { firstName, email, phone, lastName, password, rol } = response
+        const { firstName, email, phone, lastName, password, rol, plant } = response
 
         const existEmail = await prisma.users.findFirst({
             where: { email },
@@ -48,6 +48,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
                 PhoneUsers: {
                     create: {
                         phoneNumber: parseInt(phone),
+                    },
+                },
+                UserPlants: {
+                    create: {
+                        plantId: parseInt(plant),
                     },
                 },
             },

--- a/src/app/dashboard/userPlant/add/page.tsx
+++ b/src/app/dashboard/userPlant/add/page.tsx
@@ -1,14 +1,14 @@
 import { auth } from "@/lib/auth"
-import { AddUser } from "@/ui/dashboard/users/add-user"
+import { AddUserPlant } from "@/ui/dashboard/usersPlants/add-userPlants"
 import { SessionProvider } from "next-auth/react"
 
-const AddUserPage = async () => {
+const AddUserPlantPage = async () => {
     const session = await auth()
     return (
         <SessionProvider session={session}>
-            <AddUser />
+            <AddUserPlant />
         </SessionProvider>
     )
 }
 
-export default AddUserPage
+export default AddUserPlantPage

--- a/src/app/dashboard/userPlant/page.tsx
+++ b/src/app/dashboard/userPlant/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react"
+import { auth } from "@/lib/auth"
+
+import { getUserPlantByCompany } from "@/lib/services"
+import { Table } from "@/ui/dashboard/usersPlants/table"
+
+const DashboardUserPlantsPage = async () => {
+    const session = await auth()
+    const userId = session?.user?.id ? Number(session.user.id) : Number.MAX_SAFE_INTEGER
+    const plants = await getUserPlantByCompany(userId)
+
+    return (
+        <section className="min-h-main py-4 space-y-4">
+            <Suspense fallback={<p>Table...</p>}>
+                <Table userPlants={plants} />
+            </Suspense>
+        </section>
+    )
+}
+
+export default DashboardUserPlantsPage

--- a/src/lib/@types/props.ts
+++ b/src/lib/@types/props.ts
@@ -49,6 +49,14 @@ export interface FilterComapaniesProps {
         phoneCompanies?: { phoneNumber: string }[]
     }[]
 }
+export interface FilterUserPlantsProps {
+    userPlants: {
+        userId: number
+        plantId: number
+        plant?: { plantName: string }
+        user?: { firstName: string; lastName: string }
+    }[]
+}
 
 export interface FilterUserProps {
     users: Users[]

--- a/src/lib/@types/types.ts
+++ b/src/lib/@types/types.ts
@@ -1,5 +1,5 @@
 import { ReadonlyURLSearchParams } from "next/navigation"
-import { Companies, Plants, Samples, Users, Zones } from "@prisma/client"
+import { Companies, Plants, Samples, UserPlants, Users, Zones } from "@prisma/client"
 
 export interface LayoutProps {
     children: React.ReactNode
@@ -47,6 +47,8 @@ export interface Params<T extends string> {
 export type AddZonesActionState = ActionState<Omit<Zones, "zoneId" | "plantId" | "state">>
 
 export type AddPlantActionState = ActionState<Omit<Plants, "plantId" | "state">>
+
+export type AddPUserPlantsActionState = ActionState<UserPlants>
 
 export type SamplesWithoutIds = Omit<Samples, "zoneId" | "userId" | "sampleDateTime" | "sampleId">
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,12 +52,14 @@ export const UserSchema = object({
     }),
     phone: string(),
     rol: string(),
+    plant: string(),
 })
 
 export const PlantSchema = object({
     plantName: string(),
     latitude: string(),
     longitude: string(),
+    user: string(),
 })
 export const ZoneSchema = object({
     latitude: number()
@@ -68,4 +70,9 @@ export const ZoneSchema = object({
         .refine((value) => value !== 0, { message: "Longitude must be different than zero" }),
     name: string().regex(/^[a-zA-Z\s]*$/, "Please enter only letters"),
     plant: number(),
+})
+
+export const UserPlantSchema = object({
+    plant: string(),
+    user: string(),
 })

--- a/src/lib/services/plants.ts
+++ b/src/lib/services/plants.ts
@@ -1,4 +1,4 @@
-import { Plants, Zones } from "@prisma/client"
+import { Plants, UserPlants, Zones } from "@prisma/client"
 import { getFetch } from "@/lib/utils"
 
 /**
@@ -31,5 +31,10 @@ export const getZonesPlantsByUser = async (userId: number): Promise<Zones[]> => 
  */
 export const getPlantByCompany = async (userId: number): Promise<Plants[]> => {
     const { data } = await getFetch<Plants[]>(`users/${userId}/plants`)
+    return data
+}
+
+export const getUserPlantByCompany = async (userId: number): Promise<UserPlants[]> => {
+    const { data } = await getFetch<UserPlants[]>(`users/${userId}/userPlants`)
     return data
 }

--- a/src/ui/dashboard/menu.tsx
+++ b/src/ui/dashboard/menu.tsx
@@ -21,6 +21,10 @@ const links = {
         { href: "/dashboard/plants", label: "List" },
         { href: "/dashboard/plants/add", label: "Add" },
     ],
+    UserPlants: [
+        { href: "/dashboard/userPlant", label: "List" },
+        { href: "/dashboard/userPlant/add", label: "Add" },
+    ],
 }
 
 export const Menu = () => {

--- a/src/ui/dashboard/plants/add-plant.tsx
+++ b/src/ui/dashboard/plants/add-plant.tsx
@@ -6,13 +6,29 @@ import { Label } from "@halvaradop/ui-label"
 import { Button } from "@halvaradop/ui-button"
 import { addPlantAction } from "@/lib/actions"
 import { AddPlantActionState } from "@/lib/@types/types"
+import { useSession } from "next-auth/react"
+import { useEffect, useState } from "react"
+import { Users } from "@prisma/client"
+import { getUserByCompany } from "@/lib/services"
+import { Select } from "@/ui/common/select"
 
 export const AddPlant = () => {
+    const { data: session } = useSession()
+    const [users, setUsers] = useState<Users[]>([])
     const [state, formAction] = useFormState(addPlantAction, {
         message: "",
         isSuccess: false,
         schema: {} as AddPlantActionState["schema"],
     })
+    const mapUsers = users.map(({ userId, lastName }) => ({ key: lastName, value: userId.toString() }))
+    useEffect(() => {
+        const fetchUsers = async () => {
+            const userId = Number(session?.user?.id) || Number.MAX_SAFE_INTEGER
+            const response = await getUserByCompany(userId)
+            setUsers(response)
+        }
+        fetchUsers()
+    }, [])
 
     return (
         <Form className="w-full min-h-main pt-4" action={formAction}>
@@ -45,6 +61,10 @@ export const AddPlant = () => {
                     name="longitude"
                     required
                 />
+            </Label>
+            <Label className="w-full text-neutral-700" size="sm">
+                User
+                <Select name="user" values={mapUsers} />
             </Label>
             <Button className="mt-6" fullWidth>
                 Add

--- a/src/ui/dashboard/users/add-user.tsx
+++ b/src/ui/dashboard/users/add-user.tsx
@@ -6,22 +6,35 @@ import { Input } from "@halvaradop/ui-input"
 import { Label } from "@halvaradop/ui-label"
 import { Button } from "@halvaradop/ui-button"
 import { AddUserActionState } from "@/lib/@types/types"
-import { Roles } from "@prisma/client"
+import { Plants, Roles } from "@prisma/client"
 import { useEffect, useState } from "react"
-import { getRoles } from "@/lib/services"
+import { getPlantByCompany, getRoles } from "@/lib/services"
 import { Select } from "@/ui/common/select"
 import dataJson from "@/lib/data.json"
+import { useSession } from "next-auth/react"
 
 const { userInputs } = dataJson
 
 export const AddUser = () => {
+    const { data: session } = useSession()
     const [roles, setRoles] = useState<Roles[]>([])
+    const [plants, setPlants] = useState<Plants[]>([])
     const [state, formAction] = useFormState(addUserAction, {
         message: "",
         isSuccess: false,
         schema: {} as AddUserActionState["schema"],
     })
     const mapRoles = roles.map(({ roleId, roleName }) => ({ key: roleName, value: roleId.toString() }))
+    const mapPlants = plants.map(({ plantId, plantName }) => ({ key: plantName, value: plantId.toString() }))
+
+    useEffect(() => {
+        const fetchPlants = async () => {
+            const userId = Number(session?.user?.id) || Number.MAX_SAFE_INTEGER
+            const response = await getPlantByCompany(userId)
+            setPlants(response)
+        }
+        fetchPlants()
+    }, [])
 
     useEffect(() => {
         const fetchRoles = async () => {
@@ -51,6 +64,10 @@ export const AddUser = () => {
             <Label className="w-full text-neutral-700" size="sm">
                 Role
                 <Select name="rol" values={mapRoles} />
+            </Label>
+            <Label className="w-full text-neutral-700" size="sm">
+                Plant
+                <Select name="plant" values={mapPlants} />
             </Label>
             <Button className="mt-6" fullWidth>
                 Add

--- a/src/ui/dashboard/usersPlants/add-userPlants.tsx
+++ b/src/ui/dashboard/usersPlants/add-userPlants.tsx
@@ -1,0 +1,64 @@
+"use client"
+import { useFormState } from "react-dom"
+import { Form } from "@halvaradop/ui-form"
+import { Label } from "@halvaradop/ui-label"
+import { Button } from "@halvaradop/ui-button"
+import { addUserPlantsAction } from "@/lib/actions"
+import { AddPUserPlantsActionState } from "@/lib/@types/types"
+import { useSession } from "next-auth/react"
+import { useEffect, useState } from "react"
+import { Plants, Users } from "@prisma/client"
+import { getPlantByCompany, getUserByCompany } from "@/lib/services"
+import { Select } from "@/ui/common/select"
+
+export const AddUserPlant = () => {
+    const { data: session } = useSession()
+    const [users, setUsers] = useState<Users[]>([])
+    const [plants, setPlants] = useState<Plants[]>([])
+    const [state, formAction] = useFormState(addUserPlantsAction, {
+        message: "",
+        isSuccess: false,
+        schema: {} as AddPUserPlantsActionState["schema"],
+    })
+    const mapPlants = plants.map(({ plantId, plantName }) => ({ key: plantName, value: plantId.toString() }))
+    const mapUsers = users.map(({ userId, lastName }) => ({ key: lastName, value: userId.toString() }))
+    useEffect(() => {
+        const fetchUsers = async () => {
+            const userId = Number(session?.user?.id) || Number.MAX_SAFE_INTEGER
+            const response = await getUserByCompany(userId)
+            setUsers(response)
+        }
+        fetchUsers()
+    }, [])
+    useEffect(() => {
+        const fetchPlants = async () => {
+            const userId = Number(session?.user?.id) || Number.MAX_SAFE_INTEGER
+            const response = await getPlantByCompany(userId)
+            setPlants(response)
+        }
+        fetchPlants()
+    }, [])
+
+    return (
+        <Form className="w-full min-h-main pt-4" action={formAction}>
+            <Label className="w-full text-neutral-700" size="sm">
+                User
+                <Select name="user" values={mapUsers} />
+            </Label>
+            <Label className="w-full text-neutral-700" size="sm">
+                Plant
+                <Select name="plant" values={mapPlants} />
+            </Label>
+            <Button className="mt-6" fullWidth>
+                Add
+            </Button>
+            {state.message && (
+                <div
+                    className={`mt-4 p-2 rounded ${state.isSuccess ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"}`}
+                >
+                    {state.message}
+                </div>
+            )}
+        </Form>
+    )
+}

--- a/src/ui/dashboard/usersPlants/table.tsx
+++ b/src/ui/dashboard/usersPlants/table.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { FilterUserPlantsProps } from "@/lib/@types/props"
+export const Table = ({ userPlants }: FilterUserPlantsProps) => {
+    return (
+        <table className="w-full text-neutral-600 table-fixed border border-gray-1000 border-separate border-spacing-0 rounded-lg bg-white">
+            <thead>
+                <tr>
+                    <th className="py-3 pl-3">Plant</th>
+                    <th className="hidden p-3 xs:table-cell">User</th>
+                </tr>
+            </thead>
+            <tbody>
+                {userPlants.map(({ userId, plantId, plant, user }) => (
+                    <tr className="text-sm td:text-start td:font-normal" key={`${userId}-${plantId}`}>
+                        <td className="p-3 pr-0 border-t">{plant?.plantName}</td>
+                        <td className="hidden p-3 border-t xs:table-cell">
+                            {user?.firstName} {user?.lastName}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}


### PR DESCRIPTION
## Description
This PR was created so that when a user is registered, they are assigned a plant, as this is the only way to identify that the user belongs to that company. On the plant side, a user can be added, but this is optional (this feature still needs to be implemented). Additionally, it allows plants and users that have already been created to be linked, so a plant can be assigned to multiple users or a user to multiple plants.


## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->